### PR TITLE
fix ipv6 flow label construction

### DIFF
--- a/libnet/src/libnet_build_ip.c
+++ b/libnet/src/libnet_build_ip.c
@@ -442,7 +442,7 @@ const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
     memset(&ip_hdr, 0, sizeof(ip_hdr));
     ip_hdr.ip_flags[0] = (0x06 << 4) | ((tc & 0xF0) >> 4);
     ip_hdr.ip_flags[1] = ((tc & 0x0F) << 4) | ((fl & 0xF0000) >> 16);
-    ip_hdr.ip_flags[2] = fl & 0x0FF00 >> 8;
+    ip_hdr.ip_flags[2] = (fl & 0x0FF00) >> 8;
     ip_hdr.ip_flags[3] = fl & 0x000FF;
     ip_hdr.ip_len      = htons(len);
     ip_hdr.ip_nh       = nh;


### PR DESCRIPTION
shift has higher precedence than binary AND in C.  old code duplicates the first byte's content in the second byte.
