### PR TITLE
Have `libnet_name2addr4()` take const char* addr.

### DIFF
--- a/libnet/include/libnet/libnet-functions.h
+++ b/libnet/include/libnet/libnet-functions.h
@@ -243,7 +243,7 @@ libnet_addr2name4(uint32_t in, uint8_t use_name);
  */
 LIBNET_API
 uint32_t
-libnet_name2addr4(libnet_t *l, char *host_name, uint8_t use_name);
+libnet_name2addr4(libnet_t *l, const char *host_name, uint8_t use_name);
 
 extern const struct libnet_in6_addr in6addr_error;
 

--- a/libnet/src/libnet_resolve.c
+++ b/libnet/src/libnet_resolve.c
@@ -112,7 +112,7 @@ libnet_addr2name4_r(uint32_t in, uint8_t use_name, char *hostname,
 }
 
 uint32_t
-libnet_name2addr4(libnet_t *l, char *host_name, uint8_t use_name)
+libnet_name2addr4(libnet_t *l, const char *host_name, uint8_t use_name)
 {
     struct in_addr addr;
     struct hostent *host_ent; 


### PR DESCRIPTION
This is consistent with `libnet_name2addr6()` and the right thing to do.
