### PR TITLE
OSPF add missing neighbor

### DIFF
--- a/libnet/include/libnet/libnet-functions.h
+++ b/libnet/include/libnet/libnet-functions.h
@@ -1544,7 +1544,28 @@ libnet_ptag_t
 libnet_build_ospfv2_hello(uint32_t netmask, uint16_t interval, uint8_t opts,
 uint8_t priority, uint32_t dead_int, uint32_t des_rtr, uint32_t bkup_rtr,
 const uint8_t* payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag);
- 
+
+/**
+ * @param netmask
+ * @param interval
+ * @param opts
+ * @param priority
+ * @param dead_int
+ * @param des_rtr
+ * @param bkup_rtr
+ * @param neighbor
+ * @param payload optional payload or NULL
+ * @param payload_s payload length or 0
+ * @param l pointer to a libnet context
+ * @param ptag protocol tag to modify an existing header, 0 to build a new one
+ * @return protocol tag value on success
+ * @retval -1 on error
+ */
+libnet_ptag_t
+libnet_build_ospfv2_hello_neighbor(uint32_t netmask, uint16_t interval, uint8_t opts,
+uint8_t priority, uint32_t dead_int, uint32_t des_rtr, uint32_t bkup_rtr, uint32_t neighbor,
+const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag);
+
 /**
  * @param dgram_len
  * @param opts

--- a/libnet/src/libnet_build_ospf.c
+++ b/libnet/src/libnet_build_ospf.c
@@ -101,52 +101,9 @@ libnet_build_ospfv2_hello(uint32_t netmask, uint16_t interval, uint8_t opts,
 uint8_t priority, uint32_t dead_int, uint32_t des_rtr, uint32_t bkup_rtr,
 const uint8_t *payload, uint32_t payload_s, libnet_t *l, libnet_ptag_t ptag)
 {
-    uint32_t n, h;
-    libnet_pblock_t *p;
-    struct libnet_ospf_hello_hdr hello_hdr;
-
-    if (l == NULL)
-    { 
-        return (-1);
-    } 
-
-    n = LIBNET_OSPF_HELLO_H + payload_s;
-    h = 0;
-
-    /*
-     *  Find the existing protocol block if a ptag is specified, or create
-     *  a new one.
-     */
-    p = libnet_pblock_probe(l, ptag, n, LIBNET_PBLOCK_OSPF_HELLO_H);
-    if (p == NULL)
-    {
-        return (-1);
-    }
-    
-    memset(&hello_hdr, 0, sizeof(hello_hdr));
-    hello_hdr.hello_nmask.s_addr    = netmask;  /* Netmask */
-    hello_hdr.hello_intrvl          = htons(interval);	/* # seconds since last packet sent */
-    hello_hdr.hello_opts            = opts;     /* OSPF_* options */
-    hello_hdr.hello_rtr_pri         = priority; /* If 0, can't be backup */
-    hello_hdr.hello_dead_intvl      = htonl(dead_int); /* Time til router is deemed down */
-    hello_hdr.hello_des_rtr.s_addr  = des_rtr;	/* Networks designated router */
-    hello_hdr.hello_bkup_rtr.s_addr = bkup_rtr; /* Networks backup router */
-    /*hello_hdr.hello_nbr.s_addr      = htonl(neighbor); */
-
-    n = libnet_pblock_append(l, p, (uint8_t *)&hello_hdr, LIBNET_OSPF_HELLO_H);
-    if (n == -1)
-    {
-        goto bad;
-    }
-
-    /* boilerplate payload sanity check / append macro */
-    LIBNET_DO_PAYLOAD(l, p);
- 
-    return (ptag ? ptag : libnet_pblock_update(l, p, h, 
-            LIBNET_PBLOCK_OSPF_HELLO_H));
-bad:
-    libnet_pblock_delete(l, p);
-    return (-1);
+	return libnet_build_ospfv2_hello_neighbor(netmask, interval, opts,
+		  priority, dead_int, des_rtr, bkup_rtr, 0,
+		  payload, payload_s, l, ptag);
 }
 
 libnet_ptag_t


### PR DESCRIPTION
This patch adds support for a new `libnet_build_ospfv2_hello_neighbor()` API, which can be used by tools like Nemesis to set the *Active Neighbor* protocol field in OSPF HELLO messages.

The second patch, also included in this pull request, reduces code duplication by letting `libnet_build_ospfv2_hello()` call `libnet_build_ospfv2_hello_neighbor()` with the neighbor field set to 0.0.0.0