### PR TITLE
Libnet init for PCAP logging fails on active tun0

### DIFF
--- a/libnet/src/libnet_link_linux.c
+++ b/libnet/src/libnet_link_linux.c
@@ -114,6 +114,7 @@ libnet_open_link(libnet_t *l)
         case ARPHRD_SLIP6:
         case ARPHRD_CSLIP6:
         case ARPHRD_PPP:
+        case ARPHRD_NONE
             l->link_type = DLT_RAW;
             break;
         case ARPHRD_FDDI:


### PR DESCRIPTION
When initializing libnet for PCAP logging while OpenVPN has tun0 open, sslsplit fails with:

```
Failed to init pcap libnet: unknown physical layer type                
/usr/local/bin/sslsplit: failed to preinit logging.
```

Adding `ARPHRD_NONE` (`0xfffe`) to use `DLT_RAW` fixes this issue.

(https://github.com/droe/sslsplit/issues/232)