### PR TITLE
Fix number ranges produced by libnet_get_prand()

### DIFF
--- a/libnet/src/libnet_prand.c
+++ b/libnet/src/libnet_prand.c
@@ -86,15 +86,15 @@ libnet_get_prand(int mod)
     switch (mod)
     {
         case LIBNET_PR2:
-            return (n % 0x2);           /* 0 - 1 */
+            return (n & 0x1);           /* 0 - 1 */
         case LIBNET_PR8:
-            return (n % 0xff);          /* 0 - 255 */
+            return (n & 0xff);          /* 0 - 255 */
         case LIBNET_PR16:
-            return (n % 0x7fff);        /* 0 - 32767 */
+            return (n & 0x7fff);        /* 0 - 32767 */
         case LIBNET_PRu16:
-            return (n % 0xffff);        /* 0 - 65535 */
+            return (n & 0xffff);        /* 0 - 65535 */
         case LIBNET_PR32:
-            return (n % 0x7fffffff);    /* 0 - 2147483647 */
+            return (n & 0x7fffffff);    /* 0 - 2147483647 */
         case LIBNET_PRu32:
             return (n);                 /* 0 - 4294967295 */
     }


### PR DESCRIPTION
Modulo X gives a range of 0..(X-1).  `LIBNET_PR8`, `LIBNET_PR16`, `LIBNET_PRu16` and `LIBNET_PR32` all were off by one and never produced the highest number (e.g. `0xff` for `LIBNET_PR8`).

Since all of the number ranges are powers of 2, we can mask instead of modulo, which should be slightly faster; now it makes sense to use the highest number we want to produce as a mask.  Use masking also for `LIBNET_PR2`; this produces the same result but is consistent with the other ranges.