### PR TITLE
Compilation Under BSD 6.4+

### DIFF
--- a/libnet/src/libnet_link_bpf.c
+++ b/libnet/src/libnet_link_bpf.c
@@ -30,7 +30,9 @@
 #include "common.h"
 
 #include <sys/param.h>  /* optionally get BSD define */
+#ifndef __OpenBSD__
 #include <sys/timeb.h>
+#endif
 #include <sys/file.h>
 #include <sys/ioctl.h>
 


### PR DESCRIPTION
timeb does not exists in OpenBSD
and is not required